### PR TITLE
Add support for rendering grid lines in WebGL shader

### DIFF
--- a/www/src/modules/types.ts
+++ b/www/src/modules/types.ts
@@ -32,5 +32,9 @@ export type ProgramInfo = {
     };
     uniformLocations: {
         texture: WebGLUniformLocation | null;
+        resolution: WebGLUniformLocation | null;
+        gridSize: WebGLUniformLocation | null;
+        gridWidth: WebGLUniformLocation | null;
+        showGrid: WebGLUniformLocation | null;
     };
 };

--- a/www/src/modules/webgl/shaders/fragment.glsl
+++ b/www/src/modules/webgl/shaders/fragment.glsl
@@ -1,9 +1,32 @@
 precision mediump float;
 
 uniform sampler2D u_texture;
+uniform vec2 u_resolution;
+uniform float u_gridSize;
+uniform float u_gridWidth;
+uniform bool u_showGrid;
+
 varying vec2 v_texCoord;
 
 void main() {
     float v = 1.0 - texture2D(u_texture, v_texCoord).r;
-    gl_FragColor = vec4(v, v, v, 1.0);
+    vec3 cellColor = vec3(v, v, v);
+
+    if (u_showGrid) {
+        // Calculate grid lines
+        vec2 pixelCoord = v_texCoord * u_resolution;
+        vec2 gridCoord = mod(pixelCoord, u_gridSize);
+
+        // Create grid lines
+        float gridLine = 0.0;
+        if (gridCoord.x < u_gridWidth || gridCoord.y < u_gridWidth) {
+            gridLine = 1.0;
+        }
+
+        // Blend grid with cell color
+        vec3 gridColor = vec3(0.8, 0.8, 0.8); // Light gray grid
+        cellColor = mix(cellColor, gridColor, gridLine * 0.3);
+    }
+
+    gl_FragColor = vec4(cellColor, 1.0);
 }


### PR DESCRIPTION
Integrate grid rendering into the fragment shader with configurable parameters (`gridSize`, `gridWidth`, and `showGrid`). Update the WebGL rendering context to pass grid-related uniforms.

Fixes #6 